### PR TITLE
fix diagnosis and small typos

### DIFF
--- a/v2 to v3/ETL Scripts/Diagnosis_ETL.sql
+++ b/v2 to v3/ETL Scripts/Diagnosis_ETL.sql
@@ -1,4 +1,4 @@
-﻿-- condition_occurrence --> Diagnosis
+-- condition_occurrence --> Diagnosis
 -- Changes from previous version:
 ---- Drive dx_source from Observation.value_as_concept_id
 ---- Populate Pdx,raw_pdx, raw_dx_source
@@ -17,10 +17,12 @@ select distinct
 	enc.providerid,
 	-- look for ICDs, followed by SNOMED, following by others
 	case when c3.vocabulary_id in ('ICD9CM', 'ICD10','ICD10CM') 
-		then split_part(condition_source_value,'|',2) 
+		then 
+		c3.concept_code
 		else case when co.condition_concept_id>0
 		 then c2.concept_code 
-		 else split_part(condition_source_value,'|',2)  end end 
+		 else case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
+				else  trim(condition_source_value)  end  end end 
 			           as dx,
 	case when c3.vocabulary_id = 'ICD9CM'  then '09' 
 		else 
@@ -43,5 +45,6 @@ from
 	left join dcc_pcornet.cz_omop_pcornet_concept_map m2 on  cast(co.condition_type_concept_id as text) = m2.source_concept_id  and m2.source_concept_class='pdx'
 	left join vocabulary.concept c3 on co.condition_source_concept_id = c3.concept_id
 	left join vocabulary.concept c4 on co.condition_type_concept_id = c4.concept_id 
-where co.condition_type_concept_id not in (38000245)
+where 
+	co.condition_type_concept_id not in (38000245)
 

--- a/v2 to v3/ETL Scripts/start2001/ETL Scripts/chop/Diagnosis_ETL.sql
+++ b/v2 to v3/ETL Scripts/start2001/ETL Scripts/chop/Diagnosis_ETL.sql
@@ -18,12 +18,11 @@ select distinct
 	-- look for ICDs, followed by SNOMED, following by others
 	case when c3.vocabulary_id in ('ICD9CM', 'ICD10','ICD10CM') 
 		then 
-+		case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
-+			else  trim(condition_source_value)  end 
+		c3.concept_code
 		else case when co.condition_concept_id>0
 		 then c2.concept_code 
 		  else case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
-+				else  trim(condition_source_value)  end  end end  
+				else  trim(condition_source_value)  end  end end  
 			           as dx,
 	case when c3.vocabulary_id = 'ICD9CM'  then '09' 
 		else 

--- a/v2 to v3/ETL Scripts/start2001/ETL Scripts/chop/Diagnosis_ETL.sql
+++ b/v2 to v3/ETL Scripts/start2001/ETL Scripts/chop/Diagnosis_ETL.sql
@@ -17,10 +17,13 @@ select distinct
 	enc.providerid,
 	-- look for ICDs, followed by SNOMED, following by others
 	case when c3.vocabulary_id in ('ICD9CM', 'ICD10','ICD10CM') 
-		then split_part(condition_source_value,'|',2) 
+		then 
++		case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
++			else  trim(condition_source_value)  end 
 		else case when co.condition_concept_id>0
 		 then c2.concept_code 
-		 else split_part(condition_source_value,'|',2)  end end 
+		  else case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
++				else  trim(condition_source_value)  end  end end  
 			           as dx,
 	case when c3.vocabulary_id = 'ICD9CM'  then '09' 
 		else 

--- a/v2 to v3/ETL Scripts/start2001/ETL Scripts/dcc/Diagnosis_ETL.sql
+++ b/v2 to v3/ETL Scripts/start2001/ETL Scripts/dcc/Diagnosis_ETL.sql
@@ -18,12 +18,11 @@ select distinct
 	-- look for ICDs, followed by SNOMED, following by others
 	case when c3.vocabulary_id in ('ICD9CM', 'ICD10','ICD10CM') 
 		then 
-+		case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
-+			else  trim(condition_source_value)  end 
+		c3.concept_code
 		else case when co.condition_concept_id>0
 		 then c2.concept_code 
 		 else case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
-+				else  trim(condition_source_value)  end  end end 
+				else  trim(condition_source_value)  end  end end 
 			           as dx,
 	case when c3.vocabulary_id = 'ICD9CM'  then '09' 
 		else 

--- a/v2 to v3/ETL Scripts/start2001/ETL Scripts/dcc/Diagnosis_ETL.sql
+++ b/v2 to v3/ETL Scripts/start2001/ETL Scripts/dcc/Diagnosis_ETL.sql
@@ -17,10 +17,13 @@ select distinct
 	enc.providerid,
 	-- look for ICDs, followed by SNOMED, following by others
 	case when c3.vocabulary_id in ('ICD9CM', 'ICD10','ICD10CM') 
-		then split_part(condition_source_value,'|',2) 
+		then 
++		case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
++			else  trim(condition_source_value)  end 
 		else case when co.condition_concept_id>0
 		 then c2.concept_code 
-		 else split_part(condition_source_value,'|',2)  end end 
+		 else case when condition_source_Value  like '%|%' then trim(split_part(condition_source_value,'|',2))
++				else  trim(condition_source_value)  end  end end 
 			           as dx,
 	case when c3.vocabulary_id = 'ICD9CM'  then '09' 
 		else 

--- a/v2 to v3/ETL Scripts/start2001/ETL Scripts/dcc/Prescribing_ETL.sql
+++ b/v2 to v3/ETL Scripts/start2001/ETL Scripts/dcc/Prescribing_ETL.sql
@@ -34,6 +34,6 @@ from
 	left join vocabulary.concept c1 on de.drug_concept_id = c1.concept_id AND vocabulary_id = 'RxNorm'
 	left join vocabulary.concept c2 on de.drug_source_concept_id = c2.concept_id
 where
-	de.drug_type_concept_id IN ('38000177') -- 38000177 = Prescription written and
-	de.person_id IN (select person_id from dcc_start2001_pcornet.person_visit_start2001)
+	de.drug_type_concept_id IN ('38000177') -- 38000177 = Prescription written
+	and de.person_id IN (select person_id from dcc_start2001_pcornet.person_visit_start2001)
 

--- a/v2 to v3/ETL Scripts/start2001/ETL Scripts/dcc/Procedure_ETL.sql
+++ b/v2 to v3/ETL Scripts/start2001/ETL Scripts/dcc/Procedure_ETL.sql
@@ -40,7 +40,7 @@ from
 	-- get the vocabulary for the RAW_PX_TYPE field - for all cases. 
 	left join vocabulary.concept c2 on po.procedure_source_concept_id = c2.concept_id 
 	-- get the vocabulary from the procedure source value to populate the PX_TYPE field (case 2a)
-	left join dcc_start2001_pcornet.cz_omop_pcornet_concept_map m3 on c2.vocabulary_id = m3.source_concept_id AND m3.source_concept_class='Procedure Code Type';
+	left join dcc_start2001_pcornet.cz_omop_pcornet_concept_map m3 on c2.vocabulary_id = m3.source_concept_id AND m3.source_concept_class='Procedure Code Type'
 where
 	po.visit_occurrence_id IN (select visit_id from dcc_start2001_pcornet.person_visit_start2001)
 


### PR DESCRIPTION
Changes to diagnosis to accommodate sites that fail to include | in
condition_source_value and fix small typos in Prescribing and Procedure