### PR TITLE
drug_exposure_start_time doesn't exist

### DIFF
--- a/v2.6_to_3.1/ETL Scripts/Prescribing_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Prescribing_ETL.sql
@@ -20,7 +20,7 @@ select distinct
 	encounterid as encounterid,
 	de.provider_id as rx_providerid,
 	drug_exposure_start_date as rx_order_date, -- making this same as start date -- looks OK as per PEDSnet conventions doc 
-	date_part('hour',drug_exposure_start_time)||':'||date_part('minute',drug_exposure_start_time) as rx_order_time, -- same as above
+	date_part('hour',drug_exposure_start_datetime)||':'||date_part('minute',drug_exposure_start_datetime) as rx_order_time, -- same as above
 	drug_exposure_start_date as rx_start_date,
 	drug_exposure_end_date as rx_end_date,
 	round(quantity,2) as rx_quantity,
@@ -37,7 +37,7 @@ from
 	dcc_pedsnet.drug_exposure de
 	join dcc_3dot1_pcornet.demographic d on d.patid = cast(de.person_id as text)
 	join dcc_3dot1_pcornet.encounter e on cast(de.visit_occurrence_id as text) = e.encounterid
-	left join dcc_3dot1_pcornet.cz_omop_pcornet_concept_map m1 on case when de.drug_type_concept_id is null 
+	left join dcc_3dot1_pcornet.pedsnet_pcornet_valuset_map m1 on case when de.drug_type_concept_id is null 
 		AND m1.source_concept_id is null then true else cast(de.drug_type_concept_id as text) = m1.source_concept_id end and m1.source_concept_class='prescribing'
 	left join vocabulary.concept c1 on de.drug_concept_id = c1.concept_id AND vocabulary_id = 'RxNorm'
 	left join vocabulary.concept c2 on de.drug_source_concept_id = c2.concept_id


### PR DESCRIPTION
modified code, following things were changed
`drug_exposure_start_time`  to `drug_exposure_start_datetime`
and
`cz_omop_pcornet_concept_map`    to  `pedsnet_pcornet_valueset_map`

```
ERROR:  column "drug_exposure_start_time" does not exist
LINE 23:  date_part('hour',drug_exposure_start_time)||':'||date_part(...
                           ^
HINT:  Perhaps you meant to reference the column "de.drug_exposure_start_date".
```