### PR TITLE
updated condition query for data model changes

### DIFF
--- a/v2.6_to_3.1/ETL Scripts/Condition_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Condition_ETL.sql
@@ -18,11 +18,7 @@ select distinct
 		c2.concept_code
 		else case when co.condition_concept_id>0
 		 then c1.concept_code 
-		 else case when condition_source_Value  like '%|%' then 
-		 					case when co.site = 'stlouis' then trim(split_part(condition_source_value,'|',3))
-		 					else 
-		 					trim(split_part(condition_source_value,'|',2)) end 
-				else  trim(condition_source_value)  end  end end 
+		 else trim(split_part(condition_source_value,'|',3))  end  end end 
 	 as condition,
 	case when c2.vocabulary_id = 'ICD9CM'  then '09' 
 		else 

--- a/v2.6_to_3.1/ETL Scripts/Condition_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Condition_ETL.sql
@@ -18,7 +18,7 @@ select distinct
 		c2.concept_code
 		else case when co.condition_concept_id>0
 		 then c1.concept_code 
-		 else trim(split_part(condition_source_value,'|',3))  end  end end 
+		 else trim(split_part(condition_source_value,'|',3))  end  end
 	 as condition,
 	case when c2.vocabulary_id = 'ICD9CM'  then '09' 
 		else 


### PR DESCRIPTION
fixes #256

`PEDSnet CDM2.6`
guidance on populating the condition_concept_id, condition_source_concept_id, condition_source_value. These change was present in the change documentation for v2.3 to v2.4 but not as explicitly defined. The conventions below were made compulsory for version 2.6.

Diagnosis Name "|" IMO Code "|" `Diagnosis Code`

This changes the query in the script. So following script was modified.