### PR TITLE
Diagnosis script updated address PEDSnet CDM2.6

### DIFF
--- a/v2.6_to_3.1/ETL Scripts/Diagnosis_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Diagnosis_ETL.sql
@@ -16,10 +16,7 @@ select distinct
 		c3.concept_code
 		else case when co.condition_concept_id>0
 		 then c2.concept_code 
-		 else case when condition_source_Value  like '%|%' then 
-		 			case when co.site='stlouis' then trim(split_part(condition_source_value,'|',3))
-		 			else trim(split_part(condition_source_value,'|',2)) end
-				else  trim(condition_source_value)  end  end end 
+		 else trim(split_part(condition_source_value,'|',3)) end  end end 
 			           as dx,
 	case when c3.vocabulary_id = 'ICD9CM'  then '09' 
 		else 

--- a/v2.6_to_3.1/ETL Scripts/Diagnosis_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Diagnosis_ETL.sql
@@ -16,7 +16,7 @@ select distinct
 		c3.concept_code
 		else case when co.condition_concept_id>0
 		 then c2.concept_code 
-		 else trim(split_part(condition_source_value,'|',3)) end  end end 
+		 else trim(split_part(condition_source_value,'|',3)) end end 
 			           as dx,
 	case when c3.vocabulary_id = 'ICD9CM'  then '09' 
 		else 


### PR DESCRIPTION
fixes #256

`PEDSnet CDM2.6`
guidance on populating the condition_concept_id, condition_source_concept_id, condition_source_value. These change was present in the change documentation for v2.3 to v2.4 but not as explicitly defined. The conventions below were made compulsory for version 2.6.

Diagnosis Name "|" IMO Code "|" `Diagnosis Code`

This changes the query in the script. So following script was modified.