### PR TITLE
Administrative visit added to concept map

### DIFF
--- a/v2.6_to_3.1/transform_map/concept_map/concept_map.csv
+++ b/v2.6_to_3.1/transform_map/concept_map/concept_map.csv
@@ -34,6 +34,7 @@ NULL,Discharge disposition,44813951,NULL,NULL
 UN,Discharge disposition,44813951,44814653,Unknown 
 OT,Discharge disposition,44813951,44814649,Other
 OT,Discharge disposition,44813951,0,Other
+OT,Discharge disposition,2000000104,,Administrative visit
 A,Discharge disposition via visit,38004205,NULL,Adult Foster Home 
 A,Discharge disposition via visit,38004301,NULL,Assisted Living Facility 
 A,Discharge disposition via visit,4021968,NULL,Against Medical Advice 

--- a/v2.6_to_3.1/transform_map/concept_map/concept_map.csv
+++ b/v2.6_to_3.1/transform_map/concept_map/concept_map.csv
@@ -34,7 +34,6 @@ NULL,Discharge disposition,44813951,NULL,NULL
 UN,Discharge disposition,44813951,44814653,Unknown 
 OT,Discharge disposition,44813951,44814649,Other
 OT,Discharge disposition,44813951,0,Other
-OT,Discharge disposition,2000000104,,Administrative visit
 A,Discharge disposition via visit,38004205,NULL,Adult Foster Home 
 A,Discharge disposition via visit,38004301,NULL,Assisted Living Facility 
 A,Discharge disposition via visit,4021968,NULL,Against Medical Advice 
@@ -73,6 +72,7 @@ NI,Discharge status,4137274,44814650,No information
 UN,Discharge status,4137274,44814653,Unknown
 OT,Discharge status,4137274,44814649,Other
 OT,Discharge status,4137274,0,Other
+OT,Encounter type, 2000000104,,Administrative visit
 IP,Encounter type,9201,NULL,Inpatient Hospital Stay 
 AV,Encounter type,9202,NULL,Ambulatory Visit
 ED,Encounter type,9203,NULL,Emergency Department 


### PR DESCRIPTION
fixes #256
Updated and added the `Administrative visit` in concept map as `OT` in `Discharge disposition` value 
changes are made as per PEDSnet CDM2.6 as below

`Addition of "Administrative Visit" Visit Type. This is a new concept id option for the visit_concept_id field. Please see NOTE 1 for ETL guidance on the various visit categories.`