### PR TITLE
source raw_dx modified in diagnosis query

### DIFF
--- a/v2.6_to_3.1/ETL Scripts/Diagnosis_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Diagnosis_ETL.sql
@@ -27,7 +27,7 @@ select distinct
 	coalesce(m1.target_concept,'OT') as dx_source,
 	case when enc_type in ('IP','IS') then coalesce(m2.target_concept,'OT') else case when enc_type in ('ED','AV','OA') then 'X' else NULL end end as pdx,
 	coalesce(m3.target_concept,'OT') as dx_origin, 
-	concat(split_part(condition_source_value,'|',1), split_part(condition_source_value,'|',3)) as raw_dx,
+	concat(split_part(condition_source_value,'|',1), '|', split_part(condition_source_value,'|',3)) as raw_dx,
 	case when co.condition_source_concept_id = '44814649' then 'OT' else c3.vocabulary_id end as raw_dx_type,
         c4.concept_name as raw_dx_source,	
 	case when co.condition_type_concept_id IN (2000000092, 2000000093, 2000000094, 2000000098, 2000000099, 2000000100) -- if inpatient header

--- a/v2.6_to_3.1/ETL Scripts/Diagnosis_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Diagnosis_ETL.sql
@@ -27,7 +27,7 @@ select distinct
 	coalesce(m1.target_concept,'OT') as dx_source,
 	case when enc_type in ('IP','IS') then coalesce(m2.target_concept,'OT') else case when enc_type in ('ED','AV','OA') then 'X' else NULL end end as pdx,
 	coalesce(m3.target_concept,'OT') as dx_origin, 
-	condition_source_value as raw_dx,
+	concat(split_part(condition_source_value,'|',1), split_part(condition_source_value,'|',3)) as raw_dx,
 	case when co.condition_source_concept_id = '44814649' then 'OT' else c3.vocabulary_id end as raw_dx_type,
         c4.concept_name as raw_dx_source,	
 	case when co.condition_type_concept_id IN (2000000092, 2000000093, 2000000094, 2000000098, 2000000099, 2000000100) -- if inpatient header


### PR DESCRIPTION
fixes #210

refers to the [PEDSnet CDM2.6](https://github.com/PEDSnet/Data_Models/blob/master/PEDSnet/docs/Pedsnet_CDM2.5_CDM2.6_diff.md#17-condition_occurrence)

You have in your source system | condition_concept_id|condition_source_concept_id|condition_source_value
--- | --- | --- | ---
Any diagnosis that was captured as a term or name (e.g. IMO to SNOMED)| Corresponding SNOMED concept id |Corresponding concept for site diagnosis captured (must correspond to ICD9/ICD10 concept mapping) | Diagnosis Name "\|" IMO Code "\|" Diagnosis Code 

The first and the last part of the condition_source_value concatenated for raw_dx