### PR TITLE
updated condition query's  raw condition criteria

### DIFF
--- a/v2.6_to_3.1/ETL Scripts/Condition_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Condition_ETL.sql
@@ -28,7 +28,7 @@ select distinct
 	end  as condition_type, 
 	'HC' as condition_source,
 	condition_status_source_value as raw_condition_status,
-	co.condition_source_value as raw_condition,
+	concat(split_part(condition_source_value,'|',1) as raw_condition, split_part(condition_source_value,'|',3)) as raw_condition,
 	c2.vocabulary_id as raw_condition_type,
 	null as raw_condition_source ,-- it is not discretely captured in the EHRs
 	co.site as site

--- a/v2.6_to_3.1/ETL Scripts/Condition_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Condition_ETL.sql
@@ -28,7 +28,7 @@ select distinct
 	end  as condition_type, 
 	'HC' as condition_source,
 	condition_status_source_value as raw_condition_status,
-	concat(split_part(condition_source_value,'|',1) as raw_condition, split_part(condition_source_value,'|',3)) as raw_condition,
+	concat(split_part(condition_source_value,'|',1), '|' , split_part(condition_source_value,'|',3)) as raw_condition,
 	c2.vocabulary_id as raw_condition_type,
 	null as raw_condition_source ,-- it is not discretely captured in the EHRs
 	co.site as site


### PR DESCRIPTION
fixes #210

refers to the [PEDSnet CDM2.6](https://github.com/PEDSnet/Data_Models/blob/master/PEDSnet/docs/Pedsnet_CDM2.5_CDM2.6_diff.md#17-condition_occurrence)

You have in your source system | condition_concept_id|condition_source_concept_id|condition_source_value
--- | --- | --- | ---
Any diagnosis that was captured as a term or name (e.g. IMO to SNOMED)| Corresponding SNOMED concept id |Corresponding concept for site diagnosis captured (must correspond to ICD9/ICD10 concept mapping) | Diagnosis Name "\|" IMO Code "\|" Diagnosis Code 

The first and the last part of the condition_source_value concatenated for raw_condition