### PR TITLE
Modified: pedsnet_pcornet_valueset_map

### DIFF
--- a/v2.6_to_3.1/transform_map/concept_map/concept_map.csv
+++ b/v2.6_to_3.1/transform_map/concept_map/concept_map.csv
@@ -24,17 +24,14 @@ NH,Admitting source,44814678,,Nursing Home (Includes ICF)
 RH,Admitting source,44814679,,Rehabilitation Facility
 RS,Admitting source,44814680,,Residential Facility
 SN,Admitting source,8863,,Skilled Nursing Facility
-NULL,Admitting source,4145666,,NULL
 NI,Admitting source,44814650,,No information 
 UN,Admitting source,44814653,,Unknown 
 OT,Admitting source,44814649,,Other
 A,Discharge disposition,44813951,4161979,Discharged alive 
 E,Discharge disposition,44813951,4216643,Expired 
 NI,Discharge disposition,44813951,44814650,No information
-NULL,Discharge disposition,44813951,NULL,NULL
 UN,Discharge disposition,44813951,44814653,Unknown 
 OT,Discharge disposition,44813951,44814649,Other
-OT,Discharge disposition via visit,0,NULL,Other
 AF,Discharge status,38004205,,Adult Foster Home 
 AL,Discharge status,38004301,,Assisted Living Facility 
 AM,Discharge status,4021968,,Against Medical Advice 


### PR DESCRIPTION
following rows were removed from the valueset_map:

| Line number |  target_concept |source_concept_class | source_concept_id | value_as_cocept_id |concept_description|
--|--|--|--|--|--
| Line 27 |  NULL | Admitting source | 4145666 | NULL ||
|line 34|NULL|Discharge disposition|44813951|NULL|NULL|
|Line 37|OT|Discharge disposition via visit|0|NULL|Other|

Following error while running the Encounter script

> ERROR  too long value for character varying (2).

  Read NULL in target_concept as string in the insert statement 
> coalesce(m4a.target_concept,'NI') as admitting_source

admitting_source column type character varying(2)