### PR TITLE
Script to reset all table

### DIFF
--- a/v2.6_to_3.1/Reset_tables_script/trunc_fk_idx.sql
+++ b/v2.6_to_3.1/Reset_tables_script/trunc_fk_idx.sql
@@ -1,0 +1,62 @@
+-- this functions truncates, removes fK and index from all the tables in provided schema
+CREATE OR REPLACE FUNCTION truncate_schema(_schema character varying)
+  RETURNS void AS
+$BODY$
+DECLARE
+    selectrow record;
+    select_index record;
+    select_fk record;
+BEGIN
+	FOR selectrow in
+		SELECT 'TRUNCATE TABLE ' || quote_ident(_schema) || '.' ||quote_ident(t.table_name) || ' CASCADE; ' AS qry 
+		FROM (
+     			SELECT table_name 
+     			FROM information_schema.tables
+     			WHERE table_type = 'BASE TABLE' AND table_schema = _schema 
+     		)t
+	LOOP
+		EXECUTE selectrow.qry;
+    	raise info '%','truncating '||selectrow.table_name;
+	END LOOP;
+    -- -------------------------  drop all indexes  ----------------------------------------------
+    FOR select_index in 
+    	SELECT 'DROP INDEX ' || quote_ident(_schema) || '.' || quote_ident(i.indexname) ||';' AS query_idx
+        FROM (
+        		SELECT indexname, tablename, schemaname
+            	FROM pg_indexes 
+            	WHERE indexname LIKE 'idx_%' AND 
+                      schemaname = _schema AND 
+                      tablename in (
+                					  SELECT table_name 
+     								  FROM information_schema.tables
+     								  WHERE table_type = 'BASE TABLE' AND 
+                                            table_schema =  _schema
+                					)
+        	 )i
+     LOOP
+     	EXECUTE select_index.query_idx;
+     	raise info '%','dropping '||select_index.indexname;
+     END LOOP;
+     -- -----------------------  drop all foreign key constraints   -------------------------------------
+     FOR select_fk in
+     	 SELECT 'ALTER TABLE '|| quote_ident(_schema) ||'.' || quote_ident(tbl.table_name) ||' DROP CONSTRAINT ' || quote_indent(tbl.constraint_name) ||';' AS query_fk
+         FROM (
+         		SELECT constraint_name, table_name 
+         	  	FROM information_schema.table_constraints 
+                WHERE table_schema = _schema AND 
+                      constraint_name like '%_fk_%'
+              )tbl
+     LOOP
+     	EXECUTE select_fk.query_fk
+     	raise info '%','dropping '||select_fk.constraint_name;
+     END LOOP;
+end;
+$BODY$
+  LANGUAGE plpgsql;
+-- endregion function
+
+
+--  To call the function put the schema name that you want to remove constraints, index and truncate.
+--  ex. select truncate_schema('employee')
+
+select truncate_schema('SCHEMA_NAME');


### PR DESCRIPTION
fixes #276 
This script truncate all the tables. It removes all the foreign key
constraints and the indexes form the table in the provided schema name