### PR TITLE
Update Lab_Result_CM_ETL.sql

### DIFF
--- a/v2.6_to_3.1/ETL Scripts/Lab_Result_CM_ETL.sql
+++ b/v2.6_to_3.1/ETL Scripts/Lab_Result_CM_ETL.sql
@@ -1,5 +1,5 @@
 ﻿
-alter table dcc_3dot1_pcornet.lab_result_cm  alter result_num SET DATA TYPE NUMERIC(20,8);
+alter table dcc_3dot1_pcornet.lab_result_cm  alter result_num SET DATA TYPE NUMERIC(25,8);
 
 -- more changes likely to be made based on decisions in data models #203 and #204
 insert into dcc_3dot1_pcornet.lab_result_cm (


### PR DESCRIPTION
To  resolve the following error while running ETL:

> ERROR:  numeric field overflow
> DETAIL:  A field with precision 20, scale 8 must round to an absolute value less than 10^12.
> 

The result_num filed datatype length changed from 20 to 25