### PR TITLE
adding the logic to accommodate npi numeric

### DIFF
--- a/v2.9_to_v4.1/sql_etl/scripts/etl_scripts/f_provider.sql
+++ b/v2.9_to_v4.1/sql_etl/scripts/etl_scripts/f_provider.sql
@@ -1,5 +1,7 @@
 begin;
 
+ALTER TABLE SITE_pcornet.provider ALTER provider_npi SET DATA TYPE NUMERIC(20,2);
+
 Insert into SITE_pcornet.provider
 	(providerid, provider_sex, 
 	provider_specialty_primary, provider_npi,
@@ -10,7 +12,9 @@ Select
 	p.provider_id as providerid,
 	coalesce(m1.target_concept,'OT') as provider_sex,
 	coalesce(m2.target_concept,'OT') as provider_specialty_primary, 
-	p.npi as provider_npi,
+	case when p.npi ~ '[^0-9]' then null
+         else p.npi::numeric
+    end as provider_npi,
 	case when p.npi is not null then 'Y' else 'N'  end as provider_npi_flag, 
 	p.specialty_source_value as raw_provider_specialty_primary,
 	p.site as site 

--- a/v2.9_to_v4.1/sql_etl/scripts/etl_scripts/f_provider.sql
+++ b/v2.9_to_v4.1/sql_etl/scripts/etl_scripts/f_provider.sql
@@ -1,6 +1,6 @@
 begin;
 
-ALTER TABLE SITE_pcornet.provider ALTER provider_npi SET DATA TYPE NUMERIC(20,2);
+ALTER TABLE SITE_pcornet.provider ALTER provider_npi SET DATA TYPE NUMERIC(20,0);
 
 Insert into SITE_pcornet.provider
 	(providerid, provider_sex, 


### PR DESCRIPTION
fixes #416
Adding following logic to accommodate the values in numeric
note I have modified the precision to numeric(20,2) from numeric(15,8)
as i was getting following error
```  ERROR:  numeric field overflow
DETAIL:  A field with precision 16, scale 8 must round to an absolute
value less than 10^8.
SQL state: 22003 ```